### PR TITLE
Revert "Moved root location to the one set in the launcher"

### DIFF
--- a/ShiftOS/Paths.vb
+++ b/ShiftOS/Paths.vb
@@ -25,9 +25,8 @@
 
 
     'Declaration Hierarchy
-    Public appData As String = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\ShiftOSLauncher"
-    Public root As String = My.Computer.FileSystem.ReadAllText(appData + "\ExecFolder.dat") + "\"
-    'Do NOT use this unless it is for files that must go DIRECTLY in C:\ShiftOS\
+
+    Public root As String = "C:\ShiftOS\" 'Do NOT use this unless it is for files that must go DIRECTLY in C:\ShiftOS\
 
     Public progdata As String = root & "SoftwareData\"
 


### PR DESCRIPTION
Reverts ShiftOS/ShiftOS#30

Above pull request makes ShiftOS not able to be played standalone, without the launcher.